### PR TITLE
Add a wait syntactic sugar property to StepWithSelectors to reduce manual writing of waitForElement scenarios.

### DIFF
--- a/message-handler/puppeteer-json/index.ts
+++ b/message-handler/puppeteer-json/index.ts
@@ -26,29 +26,31 @@ import { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page'
 
 import { ExtensionDebuggerTransport } from './extension-debugger-transport';
 import { EMessageType } from '../../utils/constants'
-import { before as beforeUploadStep, UploadStep } from './step-handler/upload'
-import { before as beforeMultipleClicksStep, MultipleClicksStep } from './step-handler/multiple-clicks'
-import { before as beforeWaitTimeStep, WaitTimeStep } from './step-handler/wait-time'
-import { before as beforeLoopStep, LoopStep } from './step-handler/loop'
-import { before as beforeIfElementStep, IfElementStep } from './step-handler/if-element'
-import { before as beforeIfExpressionStep, IfExpressionStep } from './step-handler/if-expression'
-import { before as beforeBreakStep, BreakStep } from './step-handler/break'
-import { before as beforeInputStep, InputStep } from './step-handler/input'
-import {
-  before as beforeReturnElementStep,
-  after as afterReturnElementStep,
-  ReturnElementStep,
-  ReturnElementStepReturn
-} from './step-handler/return-element'
-import {
-  before as beforeReturnExpressionStep,
-  ReturnExpressionStep,
-  ReturnExpressionStepReturn
-} from './step-handler/return-expression'
-import {
-  after as afterNavigateStep,
-  navigateContext,
-} from './step-handler/navigate'
+
+import * as changeStep from './step-handler/change'
+import * as clickStep from './step-handler/click'
+import * as closeStep from './step-handler/close'
+import * as customStepStep from './step-handler/custom-step'
+import * as doubleClickStep from './step-handler/double-click'
+import * as emulateNetworkConditionsStep from './step-handler/emulate-network-conditions'
+import * as hoverStep from './step-handler/hover'
+import * as keyDownStep from './step-handler/key-down'
+import * as keyUpStep from './step-handler/key-up'
+import * as navigateStep from './step-handler/navigate'
+import * as scrollStep from './step-handler/scroll'
+import * as setViewportStep from './step-handler/set-viewport'
+import * as waitForElementStep from './step-handler/wait-for-element'
+import * as waitForExpressionStep from './step-handler/wait-for-expression'
+import * as uploadStep from './step-handler/upload'
+import * as multipleClicksStep from './step-handler/multiple-clicks'
+import * as waitTimeStep from './step-handler/wait-time'
+import * as loopStep from './step-handler/loop'
+import * as ifElementStep from './step-handler/if-element'
+import * as ifExpressionStep from './step-handler/if-expression'
+import * as breakStep from './step-handler/break'
+import * as returnElementStep from './step-handler/return-element'
+import * as returnExpressionStep from './step-handler/return-expression'
+import * as inputStep from './step-handler/input'
 
 export type EnhancedBaseStep = Omit<
   BaseStep,
@@ -95,32 +97,32 @@ export enum EnhancedStepType {
  */
 export type EnhancedStep = (
   | ({ comment?: string } & (
-    | Omit<ChangeStep, 'type'> & { type: EnhancedStepType.Change }
-    | Omit<ClickStep, 'type'> & { type: EnhancedStepType.Click }
-    | Omit<HoverStep, 'type'> & { type: EnhancedStepType.Hover }
-    | Omit<CloseStep, 'type'> & { type: EnhancedStepType.Close }
-    | Omit<CustomStep, 'type'> & { type: EnhancedStepType.CustomStep }
-    | Omit<DoubleClickStep, 'type'> & { type: EnhancedStepType.DoubleClick }
-    | Omit<EmulateNetworkConditionsStep, 'type'> & { type: EnhancedStepType.EmulateNetworkConditions }
-    | Omit<KeyDownStep, 'type'> & { type: EnhancedStepType.KeyDown }
-    | Omit<KeyUpStep, 'type'> & { type: EnhancedStepType.KeyUp }
-    | Omit<NavigateStep, 'type'> & { type: EnhancedStepType.Navigate }
-    | Omit<ScrollStep, 'type'> & { type: EnhancedStepType.Scroll }
-    | Omit<SetViewportStep, 'type'> & { type: EnhancedStepType.SetViewport }
-    | Omit<WaitForElementStep, 'type'> & { type: EnhancedStepType.WaitForElement }
-    | Omit<WaitForExpressionStep, 'type'> & { type: EnhancedStepType.WaitForExpression }
+    | changeStep.ChangeStep
+    | clickStep.ClickStep
+    | closeStep.CloseStep
+    | customStepStep.CustomStep
+    | doubleClickStep.DoubleClickStep
+    | emulateNetworkConditionsStep.EmulateNetworkConditionsStep
+    | hoverStep.HoverStep
+    | keyDownStep.KeyDownStep
+    | keyUpStep.KeyUpStep
+    | navigateStep.NavigateStep
+    | scrollStep.ScrollStep
+    | setViewportStep.SetViewportStep
+    | waitForElementStep.WaitForElementStep
+    | waitForExpressionStep.WaitForExpressionStep
   ))
 
-  | UploadStep
-  | MultipleClicksStep
-  | WaitTimeStep
-  | LoopStep
-  | IfElementStep
-  | IfExpressionStep
-  | BreakStep
-  | ReturnElementStep
-  | ReturnExpressionStep
-  | InputStep
+  | uploadStep.UploadStep
+  | multipleClicksStep.MultipleClicksStep
+  | waitTimeStep.WaitTimeStep
+  | loopStep.LoopStep
+  | ifElementStep.IfElementStep
+  | ifExpressionStep.IfExpressionStep
+  | breakStep.BreakStep
+  | returnElementStep.ReturnElementStep
+  | returnExpressionStep.ReturnExpressionStep
+  | inputStep.InputStep
 )
 export type EnhancedUserFlow = Omit<UserFlow, 'steps'> & { steps: EnhancedStep[] }
 
@@ -168,7 +170,7 @@ export type EnhancedUserFlow = Omit<UserFlow, 'steps'> & { steps: EnhancedStep[]
 // }
 
 export class Extension extends PuppeteerRunnerExtension {
-  result: ReturnElementStepReturn | ReturnExpressionStepReturn | null
+  result: returnElementStep.ReturnElementStepReturn | returnExpressionStep.ReturnExpressionStepReturn | null
 
   private id: string
   private senderDebuggee: chrome.debugger.Debuggee
@@ -189,100 +191,242 @@ export class Extension extends PuppeteerRunnerExtension {
   }
 
   async beforeEachStep(step: Step, flow: UserFlow) {
-    const enhancedStep = step as any as EnhancedStep
-    const enhancedFlow = flow as any as EnhancedUserFlow
-    console.group(`${
-      enhancedStep.type
-    } ${
-      (enhancedStep as any)?.name ?? ''
-    }`)
-    const id = this.id
-    const page = this.page
-    const senderDebuggee = this.senderDebuggee
-    console.log(
-      id,
-      'beforeEachStep',
-      enhancedStep.comment ?? (enhancedStep as any)?.key ?? '',
-      {enhancedStep, enhancedFlow}
-    );
-    if(enhancedStep.type === EnhancedStepType.Upload) {
-      await beforeUploadStep({
+    const enhancedStep = step as any as EnhancedStep;
+    const enhancedFlow = flow as any as EnhancedUserFlow;
+    const id = this.id;
+    // const page = this.page
+    // const senderDebuggee = this.senderDebuggee
+
+    if(enhancedStep.type === EnhancedStepType.Change) {
+      await changeStep.before({
         id,
-        step: enhancedStep as UploadStep,
-        page,
-        senderDebuggee
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.Click) {
+      await clickStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.Close) {
+      await closeStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.CustomStep) {
+      await customStepStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.DoubleClick) {
+      await doubleClickStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.EmulateNetworkConditions) {
+      await emulateNetworkConditionsStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.Hover) {
+      await hoverStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.KeyDown) {
+      await keyDownStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.KeyUp) {
+      await keyUpStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.Navigate) {
+      await navigateStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.Scroll) {
+      await scrollStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.SetViewport) {
+      await setViewportStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.WaitForElement) {
+      await waitForElementStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.WaitForExpression) {
+      await waitForExpressionStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
+      })
+    } else if(enhancedStep.type === EnhancedStepType.Upload) {
+      await uploadStep.before({
+        id,
+        step: enhancedStep,
+        flow: enhancedFlow
       })
     } else if(enhancedStep.type === EnhancedStepType.MultipleClicks) {
-      await beforeMultipleClicksStep({
+      await multipleClicksStep.before({
         id,
-        step: enhancedStep as MultipleClicksStep,
-        page,
-        flow: enhancedFlow,
+        step: enhancedStep,
+        flow: enhancedFlow
       })
     } else if(enhancedStep.type === EnhancedStepType.WaitTime) {
-      await beforeWaitTimeStep({
+      await waitTimeStep.before({
         id,
-        step: enhancedStep as WaitTimeStep,
+        step: enhancedStep,
+        flow: enhancedFlow
       })
     } else if(enhancedStep.type === EnhancedStepType.Loop) {
-      await beforeLoopStep({
+      await loopStep.before({
         id,
-        step: enhancedStep as LoopStep,
-        flow: enhancedFlow,
+        step: enhancedStep,
+        flow: enhancedFlow
       })
     } else if(enhancedStep.type === EnhancedStepType.IfElement) {
-      await beforeIfElementStep({
+      await ifElementStep.before({
         id,
-        step: enhancedStep as IfElementStep,
-        flow: enhancedFlow,
-        page,
+        step: enhancedStep,
+        flow: enhancedFlow
       })
     // } else if(enhancedStep.type === EnhancedStepType.IfExpression) {
-    //   await beforeIfExpressionStep({
+    //   await ifExpression.before({
     //     id,
-    //     step: enhancedStep as IfExpressionStep,
-    //     flow: enhancedFlow,
-    //     page,
+    //     step: enhancedStep,
+    //     flow: enhancedFlow
     //   })
     } else if(enhancedStep.type === EnhancedStepType.Break) {
-      await beforeBreakStep({
+      await breakStep.before({
         id,
-        step: enhancedStep as BreakStep,
-        flow: enhancedFlow,
+        step: enhancedStep,
+        flow: enhancedFlow
       })
     } else if(enhancedStep.type === EnhancedStepType.ReturnElement) {
-      this.result = await beforeReturnElementStep({
+      await returnElementStep.before({
         id,
-        step: enhancedStep as ReturnElementStep,
-        page,
+        step: enhancedStep,
+        flow: enhancedFlow
       })
     // } else if(enhancedStep.type === EnhancedStepType.ReturnExpression) {
-    //   this.result = await beforeReturnExpressionStep({
+    //   await returnExpressionStep.before({
     //     id,
-    //     step: enhancedStep as ReturnExpressionStep,
-    //     flow: enhancedFlow,
-    //     page,
+    //     step: enhancedStep,
+    //     flow: enhancedFlow
     //   })
     } else if(enhancedStep.type === EnhancedStepType.Input) {
-      await beforeInputStep({
+      inputStep.before({
         id,
-        step: enhancedStep as InputStep,
-        flow: enhancedFlow,
+        step: enhancedStep as inputStep.InputStep,
+        flow: enhancedFlow
       })
     }
     await super.beforeEachStep?.(step, flow);
   }
 
   async runStep(step: Step, flow: UserFlow) {
+    const enhancedStep = step as any as EnhancedStep
+    const enhancedFlow = flow as any as EnhancedUserFlow
+    const id = this.id
+    const page = this.page
+    const senderDebuggee = this.senderDebuggee
     console.log(
-      this.id,
+      id,
       'runStep',
-      (step as any)?.comment ?? (step as any).key ?? '',
       {step, flow}
     );
     if(Object.values(StepType).includes(step.type)) {
       await super.runStep?.(step, flow)
     } else {
+      if(enhancedStep.type === EnhancedStepType.Upload) {
+        await uploadStep.run({
+          id,
+          step: enhancedStep,
+          page,
+          senderDebuggee
+        })
+      } else if(enhancedStep.type === EnhancedStepType.MultipleClicks) {
+        await multipleClicksStep.run({
+          id,
+          step: enhancedStep,
+          page,
+          flow: enhancedFlow,
+        })
+      } else if(enhancedStep.type === EnhancedStepType.WaitTime) {
+        await waitTimeStep.run({
+          id,
+          step: enhancedStep,
+        })
+      } else if(enhancedStep.type === EnhancedStepType.Loop) {
+        await loopStep.run({
+          id,
+          step: enhancedStep,
+          flow: enhancedFlow,
+        })
+      } else if(enhancedStep.type === EnhancedStepType.IfElement) {
+        await ifElementStep.run({
+          id,
+          step: enhancedStep,
+          flow: enhancedFlow,
+          page,
+        })
+      // } else if(enhancedStep.type === EnhancedStepType.IfExpression) {
+      //   await runIfExpressionStep({
+      //     id,
+      //     step: enhancedStep,
+      //     flow: enhancedFlow,
+      //     page,
+      //   })
+      } else if(enhancedStep.type === EnhancedStepType.Break) {
+        await breakStep.run({
+          id,
+          step: enhancedStep,
+          flow: enhancedFlow,
+        })
+      } else if(enhancedStep.type === EnhancedStepType.ReturnElement) {
+        const result = await returnElementStep.run({
+          id,
+          step: enhancedStep,
+          page,
+        })
+        if(result) {
+          this.result = result
+        }
+      // } else if(enhancedStep.type === EnhancedStepType.ReturnExpression) {
+      //   this.result = await runReturnExpressionStep({
+      //     id,
+      //     step: enhancedStep,
+      //     flow: enhancedFlow,
+      //     page,
+      //   })
+      } else if(enhancedStep.type === EnhancedStepType.Input) {
+        await inputStep.run({
+          id,
+          step: enhancedStep,
+          flow: enhancedFlow,
+        })
+      }
       // Treat any step that are not in @puppeteer/replay as customStep.
       await super.runStep?.({type: StepType.CustomStep, name: step.type, parameters: {}}, flow)
     }
@@ -296,15 +440,15 @@ export class Extension extends PuppeteerRunnerExtension {
     // const page = this.page
     const senderDebuggee = this.senderDebuggee
     const result = this.result
-    if (step.type === StepType.Navigate) {
-      await afterNavigateStep({
+    if (enhancedStep.type === EnhancedStepType.Navigate) {
+      await navigateStep.after({
         id,
-        step: step as NavigateStep,
+        step: enhancedStep,
       }) 
     } else if(enhancedStep.type === EnhancedStepType.ReturnElement) {
-      await afterReturnElementStep({
+      await returnElementStep.after({
         id,
-        step: enhancedStep as ReturnElementStep,
+        step: enhancedStep,
         senderDebuggee,
         result,
       }) 
@@ -312,8 +456,7 @@ export class Extension extends PuppeteerRunnerExtension {
     console.log(
       id,
       'afterEachStep',
-      enhancedStep.comment ?? (enhancedStep as any).key ?? '',
-      {enhancedStep, enhancedFlow}
+      {step, flow}
     );
     console.groupEnd()
   }
@@ -339,9 +482,9 @@ export const handlePuppeteerJson = async ({
 }) => {
   const recording = request?.payload;
   if(recording) {
-    navigateContext.updateContextUrl(recording)
+    navigateStep.navigateContext.updateContextUrl(recording)
     // create first tab
-    const firstNavigatorUrl = navigateContext.getContext()[0].url
+    const firstNavigatorUrl = navigateStep.navigateContext.getContext()[0].url
     const tab = await chrome.tabs.create({ url: firstNavigatorUrl })
 
     console.log(id, {tab, sender, recording});
@@ -362,7 +505,7 @@ export const handlePuppeteerJson = async ({
       });
       const [page] = await browser.pages();
 
-      navigateContext.updateContext(0, {
+      navigateStep.navigateContext.updateContext(0, {
         url: firstNavigatorUrl,
         debuggee,
         browser,

--- a/message-handler/puppeteer-json/step-handler/break.ts
+++ b/message-handler/puppeteer-json/step-handler/break.ts
@@ -2,9 +2,26 @@ import { EnhancedStepType, EnhancedBaseStep, EnhancedUserFlow } from '../'
 import { loopParentChildrenMap } from './loop'
 
 export type BreakStep = EnhancedBaseStep & {
+  comment?: string,
   type: EnhancedStepType.Break
 }
 export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: BreakStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}
+export const run = async ({
   id,
   step,
   flow,

--- a/message-handler/puppeteer-json/step-handler/change.ts
+++ b/message-handler/puppeteer-json/step-handler/change.ts
@@ -1,0 +1,40 @@
+import {
+  ChangeStep as OriginChangeStep
+} from '@puppeteer/replay'
+
+import { EnhancedStepType, EnhancedUserFlow } from '../index'
+import { asAProperty as asAWaitForElementProperty } from './wait-for-element'
+
+export type ChangeStep = Omit<
+  OriginChangeStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.Change,
+  waitForElement?: boolean
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: ChangeStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.waitForElement ? '.waitForElement' : ''
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+
+  await asAWaitForElementProperty({
+    id,
+    step,
+    flow
+  })
+}

--- a/message-handler/puppeteer-json/step-handler/click.ts
+++ b/message-handler/puppeteer-json/step-handler/click.ts
@@ -1,0 +1,40 @@
+import {
+  ClickStep as OriginClickStep
+} from '@puppeteer/replay'
+
+import { EnhancedStepType, EnhancedUserFlow } from '../index'
+import * as waitForElementStep from './wait-for-element'
+
+export type ClickStep = Omit<
+  OriginClickStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.Click,
+  waitForElement?: boolean
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: ClickStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.waitForElement ? '.waitForElement' : ''
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+
+  await waitForElementStep.asAProperty({
+    id,
+    step,
+    flow
+  })
+}

--- a/message-handler/puppeteer-json/step-handler/close.ts
+++ b/message-handler/puppeteer-json/step-handler/close.ts
@@ -1,0 +1,30 @@
+import {
+  CloseStep as OriginCloseStep
+} from '@puppeteer/replay'
+
+import { EnhancedStepType, EnhancedUserFlow } from '../index'
+
+export type CloseStep = Omit<
+  OriginCloseStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.Close,
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: CloseStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}

--- a/message-handler/puppeteer-json/step-handler/custom-step.ts
+++ b/message-handler/puppeteer-json/step-handler/custom-step.ts
@@ -1,0 +1,33 @@
+import {
+  CustomStep as OriginCustomStep
+} from '@puppeteer/replay'
+
+import { EnhancedStep, EnhancedStepType, EnhancedUserFlow } from '../index'
+
+export type CustomStep = Omit<
+  OriginCustomStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.CustomStep,
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: CustomStep,
+  flow: EnhancedUserFlow,
+}) => {
+  const enhancedStep = step as any as EnhancedStep
+  console.group(`${
+    step.type
+  }${
+    step?.name ? ` "${step?.name}"` : ''
+  }${
+    enhancedStep?.comment ? ` "${enhancedStep?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}

--- a/message-handler/puppeteer-json/step-handler/double-click.ts
+++ b/message-handler/puppeteer-json/step-handler/double-click.ts
@@ -1,0 +1,40 @@
+import {
+  DoubleClickStep as OriginDoubleClickStep
+} from '@puppeteer/replay'
+
+import { EnhancedStepType, EnhancedUserFlow } from '../index'
+import * as waitForElementStep from './wait-for-element'
+
+export type DoubleClickStep = Omit<
+  OriginDoubleClickStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.DoubleClick,
+  waitForElement?: boolean
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: DoubleClickStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.waitForElement ? '.waitForElement' : ''
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+
+  await waitForElementStep.asAProperty({
+    id,
+    step,
+    flow
+  })
+}

--- a/message-handler/puppeteer-json/step-handler/emulate-network-conditions.ts
+++ b/message-handler/puppeteer-json/step-handler/emulate-network-conditions.ts
@@ -1,0 +1,31 @@
+import {
+  EmulateNetworkConditionsStep as OriginEmulateNetworkConditionsStep
+} from '@puppeteer/replay'
+
+import { EnhancedStepType, EnhancedUserFlow } from '../index'
+
+export type EmulateNetworkConditionsStep = Omit<
+  OriginEmulateNetworkConditionsStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.EmulateNetworkConditions,
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: EmulateNetworkConditionsStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+
+}

--- a/message-handler/puppeteer-json/step-handler/hover.ts
+++ b/message-handler/puppeteer-json/step-handler/hover.ts
@@ -1,0 +1,40 @@
+import {
+  HoverStep as OriginHoverStep
+} from '@puppeteer/replay'
+
+import { EnhancedStepType, EnhancedUserFlow } from '../index'
+import * as waitForElementStep from './wait-for-element'
+
+export type HoverStep = Omit<
+  OriginHoverStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.Hover,
+  waitForElement?: boolean
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: HoverStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.waitForElement ? '.waitForElement' : ''
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+
+  await waitForElementStep.asAProperty({
+    id,
+    step,
+    flow
+  })
+}

--- a/message-handler/puppeteer-json/step-handler/if-element.ts
+++ b/message-handler/puppeteer-json/step-handler/if-element.ts
@@ -4,18 +4,45 @@ import {
 import { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page'
 import { Frame } from 'puppeteer-core/lib/esm/puppeteer/api/Frame'
 
-import { EnhancedBaseStep, EnhancedStepType, EnhancedStep, EnhancedUserFlow } from '../'
+import { EnhancedBaseStep, EnhancedStepType, EnhancedStep, EnhancedUserFlow } from '../index'
 import { querySelectorsAll, getFrame } from '../utils'
 import { comparators } from '../constants'
+import * as waitForElementStep from './wait-for-element'
 
 export type IfElementStep = EnhancedBaseStep & Omit<
   WaitForElementStep, 'type'
 > & {
+  comment?: string,
   type: EnhancedStepType.IfElement,
   steps?: EnhancedStep[],
   elseSteps?: EnhancedStep[],
+  waitForElement?: boolean,
 }
 export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: IfElementStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.waitForElement ? '.waitForElement' : ''
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+
+  await waitForElementStep.asAProperty({
+    id,
+    step,
+    flow
+  })
+}
+export const run = async ({
   id,
   step,
   flow,

--- a/message-handler/puppeteer-json/step-handler/if-expression.ts
+++ b/message-handler/puppeteer-json/step-handler/if-expression.ts
@@ -10,11 +10,28 @@ export type IfExpressionStep = EnhancedBaseStep & Omit<
   WaitForExpressionStep,
  'type'
 > & {
+  comment?: string,
   type: EnhancedStepType.IfExpression,
   steps?: EnhancedStep[],
   elseSteps?: EnhancedStep[],
 }
 export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: IfExpressionStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}
+export const run = async ({
   id,
   step,
   flow,

--- a/message-handler/puppeteer-json/step-handler/input.ts
+++ b/message-handler/puppeteer-json/step-handler/input.ts
@@ -1,10 +1,29 @@
 import { EnhancedStepType, EnhancedBaseStep, EnhancedUserFlow, EnhancedStep } from '../'
 
 export type InputStep = EnhancedBaseStep & {
+  comment?: string,
   type: EnhancedStepType.Input,
   text: string,
 }
-export const before = async ({
+export const before = ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: InputStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.text ? ` "${step?.text}"` : ''
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}
+export const run = async ({
   id,
   step,
   flow,

--- a/message-handler/puppeteer-json/step-handler/key-down.ts
+++ b/message-handler/puppeteer-json/step-handler/key-down.ts
@@ -1,0 +1,33 @@
+import {
+  KeyDownStep as OriginKeyDownStep
+} from '@puppeteer/replay'
+
+import { EnhancedStep, EnhancedStepType, EnhancedUserFlow } from '../index'
+
+export type KeyDownStep = Omit<
+  OriginKeyDownStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.KeyDown,
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: KeyDownStep,
+  flow: EnhancedUserFlow,
+}) => {
+  const enhancedStep = step as any as EnhancedStep
+  console.group(`${
+    step.type
+  }${
+    step?.key ? ` "${step?.key}"` : ''
+  }${
+    enhancedStep?.comment ? ` "${enhancedStep?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}

--- a/message-handler/puppeteer-json/step-handler/key-up.ts
+++ b/message-handler/puppeteer-json/step-handler/key-up.ts
@@ -1,0 +1,33 @@
+import {
+  KeyUpStep as OriginKeyUpStep
+} from '@puppeteer/replay'
+
+import { EnhancedStep, EnhancedStepType, EnhancedUserFlow } from '../index'
+
+export type KeyUpStep = Omit<
+  OriginKeyUpStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.KeyUp,
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: KeyUpStep,
+  flow: EnhancedUserFlow,
+}) => {
+  const enhancedStep = step as any as EnhancedStep
+  console.group(`${
+    step.type
+  }${
+    step?.key ? ` "${step?.key}"` : ''
+  }${
+    enhancedStep?.comment ? ` "${enhancedStep?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}

--- a/message-handler/puppeteer-json/step-handler/loop.ts
+++ b/message-handler/puppeteer-json/step-handler/loop.ts
@@ -1,6 +1,7 @@
 import { EnhancedStepType, EnhancedBaseStep, EnhancedStep, EnhancedUserFlow } from '../'
 
 export type LoopStep = EnhancedBaseStep & {
+  comment?: string,
   type: EnhancedStepType.Loop,
   count?: number,
   steps?: EnhancedStep[],
@@ -9,6 +10,23 @@ export type LoopStep = EnhancedBaseStep & {
 export const loopParentChildrenMap = new Map<EnhancedStep, LoopStep>()
 
 export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: LoopStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}
+
+export const run = async ({
   id,
   step,
   flow,

--- a/message-handler/puppeteer-json/step-handler/multiple-clicks.ts
+++ b/message-handler/puppeteer-json/step-handler/multiple-clicks.ts
@@ -8,6 +8,7 @@ import { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page'
 import { Frame } from 'puppeteer-core/lib/esm/puppeteer/api/Frame'
 
 import { EnhancedUserFlow, EnhancedStepType, EnhancedBaseStep, EnhancedStep } from '../'
+import * as waitForElementStep from './wait-for-element'
 import { getFrame } from '../utils'
 
 async function waitForEvents(pageOrFrame: Frame | Page, step: EnhancedStep, timeout: number) {
@@ -33,11 +34,38 @@ export type MultipleClicksStep = EnhancedBaseStep & Omit<
   ClickStep,
   'type'
 > & {
+  comment?: string,
   type: EnhancedStepType.MultipleClicks,
   count?: number,
+  waitForElement?: boolean,
 }
 
 export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: MultipleClicksStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.waitForElement ? '.waitForElement' : ''
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+
+  await waitForElementStep.asAProperty({
+    id,
+    step,
+    flow
+  })
+}
+
+export const run = async ({
   id,
   step,
   page,

--- a/message-handler/puppeteer-json/step-handler/navigate.ts
+++ b/message-handler/puppeteer-json/step-handler/navigate.ts
@@ -1,5 +1,5 @@
 import {
-  NavigateStep,
+  NavigateStep as OriginNavigateStep,
   UserFlow,
   StepType,
 } from '@puppeteer/replay';
@@ -8,6 +8,15 @@ import { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page'
 // import { Puppeteer } from 'puppeteer-core/lib/esm/puppeteer/common/Puppeteer.js';
 
 // import { ExtensionDebuggerTransport } from '../extension-debugger-transport';
+import { EnhancedStep, EnhancedStepType, EnhancedUserFlow } from '../index'
+
+export type NavigateStep = Omit<
+  OriginNavigateStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.Navigate,
+}
 
 type Context = {
   url: string
@@ -48,6 +57,26 @@ class NavigateContext {
 
 export const navigateContext = new NavigateContext()
 
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: NavigateStep,
+  flow: EnhancedUserFlow,
+}) => {
+  const enhancedStep = step as any as EnhancedStep
+  console.group(`${
+    step.type
+  }${
+    step?.url ? ` "${step?.url}"` : ''
+  }${
+    enhancedStep?.comment ? ` "${enhancedStep?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}
+
 export const after = async ({
   id,
   step,
@@ -55,6 +84,6 @@ export const after = async ({
   id: string,
   step: NavigateStep,
 }) => {
-  console.log(id, 'after navigate step', {step})
+  console.log(id, 'afterEachStep', {step})
   // TODO multiple context
 }

--- a/message-handler/puppeteer-json/step-handler/return-element.ts
+++ b/message-handler/puppeteer-json/step-handler/return-element.ts
@@ -5,7 +5,7 @@ import { Page } from 'puppeteer-core/lib/esm/puppeteer/api/Page'
 import { Frame } from 'puppeteer-core/lib/esm/puppeteer/api/Frame'
 import { STATUS_TEXTS } from 'puppeteer-core/lib/esm/puppeteer/api/HTTPRequest.js'
 
-import { EnhancedBaseStep, EnhancedStepType } from '../'
+import { EnhancedBaseStep, EnhancedStepType, EnhancedUserFlow } from '../index'
 import { querySelectorsAll, getFrame } from '../utils'
 import { comparators } from '../constants'
 import { singletonDebugger } from '../../../utils/singleton-debugger'
@@ -15,7 +15,9 @@ export type ReturnElementStep = EnhancedBaseStep & Omit<
   WaitForElementStep,
   'type'
 > & {
+  comment?: string,
   type: EnhancedStepType.ReturnElement,
+  waitForElement?: boolean,
 }
 export type ReturnElementStepReturn = {
   elements?: string[],
@@ -66,8 +68,24 @@ const hookFetchResponse = async ({
     // chrome.debugger.detach(debuggee)
   }
 }
-
 export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: ReturnElementStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}
+
+export const run = async ({
   id,
   step,
   page,
@@ -75,7 +93,7 @@ export const before = async ({
   id: string,
   step: ReturnElementStep,
   page: Page,
-}): Promise<ReturnElementStepReturn> => {
+}): Promise<ReturnElementStepReturn | undefined> => {
   // refer to https://github.com/puppeteer/replay/blob/e2c85b98e497c9191eae5a2d23429588fcd5849e/src/PuppeteerRunnerExtension.ts#L356
   async function getElementsOuterHTML(
     step: ReturnElementStep,

--- a/message-handler/puppeteer-json/step-handler/return-expression.ts
+++ b/message-handler/puppeteer-json/step-handler/return-expression.ts
@@ -10,6 +10,7 @@ export type ReturnExpressionStep = EnhancedBaseStep & Omit<
   WaitForExpressionStep,
   'type'
 > & {
+  comment?: string,
   type: EnhancedStepType.ReturnExpression,
 }
 export type ReturnExpressionStepReturn = {
@@ -17,6 +18,24 @@ export type ReturnExpressionStepReturn = {
   type: EnhancedStepType.ReturnExpression
 }
 export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: ReturnExpressionStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}
+
+
+export const run = async ({
   id,
   step,
   flow,

--- a/message-handler/puppeteer-json/step-handler/scroll.ts
+++ b/message-handler/puppeteer-json/step-handler/scroll.ts
@@ -1,0 +1,40 @@
+import {
+  ScrollStep as OriginScrollStep
+} from '@puppeteer/replay'
+
+import { EnhancedStepType, EnhancedUserFlow } from '../index'
+import { asAProperty as asAWaitForElementProperty } from './wait-for-element'
+
+export type ScrollStep = Omit<
+  OriginScrollStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.Scroll,
+  waitForElement?: boolean
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: ScrollStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.waitForElement ? '.waitForElement' : ''
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+
+  await asAWaitForElementProperty({
+    id,
+    step,
+    flow
+  })
+}

--- a/message-handler/puppeteer-json/step-handler/set-viewport.ts
+++ b/message-handler/puppeteer-json/step-handler/set-viewport.ts
@@ -1,0 +1,30 @@
+import {
+  SetViewportStep as OriginSetViewportStep
+} from '@puppeteer/replay'
+
+import { EnhancedStepType, EnhancedUserFlow } from '../index'
+
+export type SetViewportStep = Omit<
+  OriginSetViewportStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.SetViewport,
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: SetViewportStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}

--- a/message-handler/puppeteer-json/step-handler/wait-for-element.ts
+++ b/message-handler/puppeteer-json/step-handler/wait-for-element.ts
@@ -1,0 +1,58 @@
+import {
+  WaitForElementStep as OriginWaitForElementStep,
+  Selector
+} from '@puppeteer/replay';
+import { EnhancedStep, EnhancedBaseStep, EnhancedUserFlow, EnhancedStepType } from '../index'
+
+export type WaitForElementStep = Omit<
+  OriginWaitForElementStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.WaitForElement,
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: WaitForElementStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}
+
+export const asAProperty = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: EnhancedBaseStep & { waitForElement?: boolean, selectors?: Selector[] },
+  flow: EnhancedUserFlow,
+}) => {
+  console.log(id, "waitForElementStep asAProperty", {step, flow});
+  const stepIndex = flow.steps.lastIndexOf(step as EnhancedStep);
+  if(step && step.selectors && step.waitForElement) {
+    // [{type: EnhancedStepType.Click, waitForElement: true}]
+    // =>
+    // [{type: EnhancedStepType.WaitForElement}, {type: EnhancedStepType.Click}]
+    const {waitForElement, ...newStep} = step;
+    // Change the type of the current step to execute as a WaitForElement step.
+    step.type = EnhancedStepType.WaitForElement;
+    step.waitForElement = false;
+    // Insert the steps for actual execution.
+    const insertSteps = [newStep] as EnhancedStep[]
+    if(insertSteps?.length) {
+      flow.steps.splice(stepIndex + 1, 0, ...insertSteps);
+    }
+    console.log(id, { step, flow, waitForElement, insertSteps })
+  }
+}

--- a/message-handler/puppeteer-json/step-handler/wait-for-expression.ts
+++ b/message-handler/puppeteer-json/step-handler/wait-for-expression.ts
@@ -1,0 +1,30 @@
+import {
+  WaitForExpressionStep as OriginWaitForExpressionStep
+} from '@puppeteer/replay'
+
+import { EnhancedStepType, EnhancedUserFlow } from '../index'
+
+export type WaitForExpressionStep = Omit<
+  OriginWaitForExpressionStep,
+  'type'
+> & {
+  comment?: string,
+  type: EnhancedStepType.WaitForExpression,
+}
+
+export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: WaitForExpressionStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}

--- a/message-handler/puppeteer-json/step-handler/wait-time.ts
+++ b/message-handler/puppeteer-json/step-handler/wait-time.ts
@@ -1,16 +1,33 @@
 import {
   StepWithFrame,
 } from '@puppeteer/replay';
-import { EnhancedStepType, EnhancedBaseStep } from '../'
+import { EnhancedStepType, EnhancedBaseStep, EnhancedUserFlow } from '../'
 
 export type WaitTimeStep = EnhancedBaseStep & Omit<
   StepWithFrame,
  'timeout' | 'type'
 > & {
+  comment?: string,
   type: EnhancedStepType.WaitTime,
   time: number,
 }
 export const before = async ({
+  id,
+  step,
+  flow,
+}: {
+  id: string,
+  step: WaitTimeStep,
+  flow: EnhancedUserFlow,
+}) => {
+  console.group(`${
+    step.type
+  }${
+    step?.comment ? ` "${step?.comment}"` : ''
+  }`);
+  console.log(id, 'beforeEachStep', {step, flow});
+}
+export const run = async ({
   id,
   step,
 }: {


### PR DESCRIPTION
Add a wait syntactic sugar property to StepWithSelectors to reduce manual writing of waitForElement scenarios. #6 